### PR TITLE
Update cors.php

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -13,7 +13,7 @@ return [
      */
     'supportsCredentials' => true,
     'allowedOrigins' => ['*'],
-    'allowedHeaders' => ['Content-Type', 'Accept', 'Authorization', 'X-Requested-With'],
+    'allowedHeaders' => ['Content-Type', 'Accept', 'Authorization', 'X-Requested-With', 'Origin'],
     'allowedMethods' => ['GET', 'POST', 'PUT', 'DELETE'],
     'exposedHeaders' => ['Authorization'],
     'maxAge' => 0,


### PR DESCRIPTION
Safari and Mobile Safari don't work when running the API and front-end on different domains with the default CORS configuration. Adding 'Origin' to the allowedHeaders in config/cors.php resolves this issue.