### PR TITLE
extend dingo api formrequest class

### DIFF
--- a/app/Api/Requests/DogRequest.php
+++ b/app/Api/Requests/DogRequest.php
@@ -2,9 +2,9 @@
 
 namespace Api\Requests;
 
-use App\Http\Requests\Request;
+use Dingo\Api\Http\FormRequest;
 
-class DogRequest extends Request
+class DogRequest extends FormRequest
 {
 	public function authorize()
 	{

--- a/app/Api/Requests/UserRequest.php
+++ b/app/Api/Requests/UserRequest.php
@@ -2,9 +2,9 @@
 
 namespace Api\Requests;
 
-use App\Http\Requests\Request;
+use Dingo\Api\Http\FormRequest;
 
-class UserRequest extends Request
+class UserRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
When you are extending laravel form request class you will not get the **`error response correctly`**. So it's suggested when using **`dingo api & form request`** should be extending dingo api **`FormRequest`** class.

> You can check this issues https://github.com/dingo/api/issues/562, https://github.com/dingo/api/issues/535 & https://github.com/dingo/api/issues/462